### PR TITLE
chore: bump for lean4#3159

### DIFF
--- a/Alloy/Util/Command.lean
+++ b/Alloy/Util/Command.lean
@@ -13,7 +13,7 @@ open Lean Elab Command
   .node (.ofCommandInfo { elaborator, stx }) trees
 
 /-- Create context info for the info tree from the current state of command elaboration.  -/
-def mkCommandElabContextInfo : CommandElabM ContextInfo := do
+def mkCommandElabContextInfo : CommandElabM CommandContextInfo := do
   let ctx ← read; let s ← get; let scope := s.scopes.head!
   return  {
     env := s.env, fileMap := ctx.fileMap, mctx := {}, currNamespace := scope.currNamespace,
@@ -22,7 +22,7 @@ def mkCommandElabContextInfo : CommandElabM ContextInfo := do
 
 /-- Create an info tree for an elaborator with the current command elaboration context. -/
 @[inline] def mkCommandElabInfoTree (elaborator : Name) (stx : Syntax) (trees : PersistentArray InfoTree) : CommandElabM InfoTree := do
-  return .context (← mkCommandElabContextInfo) (mkElabInfoTree elaborator stx trees)
+  return .context (.commandCtx (← mkCommandElabContextInfo)) (mkElabInfoTree elaborator stx trees)
 
 /-- Adapted from the private `elabCommandUsing` definition in `Lean.Elab.Command`. -/
 def elabCommandUsing (stx : Syntax) : List (KeyedDeclsAttribute.AttributeEntry CommandElab) → CommandElabM Bool

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:4.3.0
+leanprover/lean4-pr-releases:pr-release-3159


### PR DESCRIPTION
This PR bumps alloy for the changes in leanprover/lean4#3159. It should be merged when the v4.6.0 RC is released. Before merging, the toolchain needs to be adjusted.