### PR TITLE
Replace `mkAuxName` with `mkAuxDeclName`

### DIFF
--- a/Alloy/C/Enum.lean
+++ b/Alloy/C/Enum.lean
@@ -23,7 +23,7 @@ def findIRType (constName : Name) : MetaM IR.IRType := do
   forallTelescope info.type fun as _ => do
   let levels := levelParams.map mkLevelParam
   let type := mkAppN (mkConst constName levels) as
-  let name ← mkAuxName constName 0
+  let name ← mkAuxDeclName constName
   let decl := .opaqueDecl {
     name, levelParams
     type := ← mkForallFVars as <| ← mkArrow type type

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,4 +1,4 @@
-{"version": 7,
+{"version": "1.1.0",
  "packagesDir": ".lake/packages",
  "packages": [],
  "name": "alloy",

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.19.0
+leanprover/lean4:v4.21.0


### PR DESCRIPTION
[Recently](https://github.com/leanprover/lean4/commit/4d58a3d124faeab01f7e9da33f6a7a2031ae596e), the `mkAuxName` function was removed in favor of `mkAuxDeclName`, which causes a compiler error in Alloy starting with Lean 4.21.0. This PR resolves the issue by replacing `mkAuxName` with `mkAuxDeclName`.